### PR TITLE
LABTSKINC-317: Feedback-Main-Button-Klicken

### DIFF
--- a/Assets/Scenes/MainGame.unity
+++ b/Assets/Scenes/MainGame.unity
@@ -1569,10 +1569,10 @@ RectTransform:
   m_Father: {fileID: 1136283108}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 1920, y: 1080}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &52012304
 MonoBehaviour:
@@ -15398,8 +15398,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 238.36784, y: 35.87671}
-  m_SizeDelta: {x: 226.7347, y: 124.7914}
+  m_AnchoredPosition: {x: 296, y: 62.396}
+  m_SizeDelta: {x: 306.73468, y: 124.7914}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1317190608
 MonoBehaviour:
@@ -19708,7 +19708,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 250, y: 100}
+  m_SizeDelta: {x: 330, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1788361375
 MonoBehaviour:
@@ -24738,7 +24738,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -20, y: 57.857056}
+  m_AnchoredPosition: {x: -20, y: 57.857117}
   m_SizeDelta: {x: 40, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &265050176604059349
@@ -33553,7 +33553,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &8955736995009842910
 MonoBehaviour:

--- a/Assets/Scripts/MainGame/DummyButton.cs
+++ b/Assets/Scripts/MainGame/DummyButton.cs
@@ -77,7 +77,7 @@ public class DummyButton : MonoBehaviour
     public void VisualizeButtonClick() {
         
         visualClickObject.SetActive(false);
-        visualClickObject.transform.position = new Vector3(1150f, 580f, 0);
+        visualClickObject.transform.position = new Vector3(Random.Range(800f ,1300f + 1), Random.Range(500f,650f + 1), 0);
         visualClickObject.SetActive(true);
         StopAllCoroutines();
         StartCoroutine(Fly());
@@ -88,7 +88,7 @@ public class DummyButton : MonoBehaviour
         for (int i = 0; i <= 19; i++) 
         { 
         yield return new WaitForSeconds(0.01f);
-        visualClickObject.transform.position = new Vector3(visualClickObject.transform.position.x, visualClickObject.transform.position.y, 0);
+        visualClickObject.transform.position = new Vector3(visualClickObject.transform.position.x, visualClickObject.transform.position.y + 2, 0);
         }
         visualClickObject.SetActive(false) ;
     }

--- a/Assets/Scripts/MainGame/DummyButton.cs
+++ b/Assets/Scripts/MainGame/DummyButton.cs
@@ -40,8 +40,6 @@ public class DummyButton : MonoBehaviour
         }
     }
 
-
-
     public void MainButtonAction()
     {
         float randValue = Random.value;
@@ -80,13 +78,14 @@ public class DummyButton : MonoBehaviour
 
     public void VisualizeButtonClick() {
         visualClickObject.SetActive(false);
-        visualClickObject.transform.position = new Vector3(Random.Range(Screen.width / 2 * 0.95f,Screen.width /2 * 1.3f), Random.Range(Screen.height / 2 * 0.8f,Screen.height / 2 * 1.18f), 0);
+        visualClickObject.transform.position = 
+            new Vector3(Random.Range(Screen.width / 2 * 0.95f,Screen.width /2 * 1.3f), Random.Range(Screen.height / 2 * 0.8f,Screen.height / 2 * 1.18f), 0);
         visualClickObject.SetActive(true);
         StopAllCoroutines();
         StartCoroutine(Fly());
-        
     }
 
+    // Numbers are flying for 19 pixels upwards
     IEnumerator Fly() {
         for (int i = 0; i <= 19; i++) 
         { 

--- a/Assets/Scripts/MainGame/DummyButton.cs
+++ b/Assets/Scripts/MainGame/DummyButton.cs
@@ -80,7 +80,7 @@ public class DummyButton : MonoBehaviour
 
     public void VisualizeButtonClick() {
         visualClickObject.SetActive(false);
-        visualClickObject.transform.position = new Vector3(Random.Range(Screen.width / 2 * 0.95f,Screen.width /2 * 1.35f), Random.Range(Screen.height / 2 * 0.85f,Screen.height / 2 * 1.18f), 0);
+        visualClickObject.transform.position = new Vector3(Random.Range(Screen.width / 2 * 0.95f,Screen.width /2 * 1.3f), Random.Range(Screen.height / 2 * 0.8f,Screen.height / 2 * 1.18f), 0);
         visualClickObject.SetActive(true);
         StopAllCoroutines();
         StartCoroutine(Fly());

--- a/Assets/Scripts/MainGame/DummyButton.cs
+++ b/Assets/Scripts/MainGame/DummyButton.cs
@@ -37,6 +37,7 @@ public class DummyButton : MonoBehaviour
             int creditsWithoutCrit = basePoints * multiplicator * multiplicatorOfSkin;
             Account.credits += creditsWithoutCrit;
             VisualizeButtonClick();
+            clicktext.color = Color.black;
             clicktext.text = "+" + creditsWithoutCrit;
         }
         

--- a/Assets/Scripts/MainGame/DummyButton.cs
+++ b/Assets/Scripts/MainGame/DummyButton.cs
@@ -21,37 +21,23 @@ public class DummyButton : MonoBehaviour
         visualClickObject.SetActive(false);
     }
 
-    private void Update()
-    {
-        float randValue = Random.value;
-        if (randValue > (1.0f - criticalChance))
-        {
-
-            int pointsWithCrit = (int)System.Math.Round(basePoints * multiplicator * multiplicatorOfSkin * criticalMultiplicator);
-            clicktext.color = Color.red;
-            clicktext.text = "+" + pointsWithCrit;
-            
-        }
-        else
-        { 
-            int pointsWithoutCrit = basePoints * multiplicator * multiplicatorOfSkin;
-            clicktext.text = "+" + pointsWithoutCrit;
-
-        }
-    }
-
     public void MainButtonAction()
     {
         float randValue = Random.value;
         if (randValue > (1.0f - criticalChance))
         {
-            Account.credits += (int)System.Math.Round(basePoints * multiplicator * multiplicatorOfSkin * criticalMultiplicator);
+            int creditsWithCrit = (int)System.Math.Round(basePoints * multiplicator * multiplicatorOfSkin * criticalMultiplicator);
+            Account.credits += creditsWithCrit;
             VisualizeButtonClick();
+            clicktext.color = Color.red;
+            clicktext.text = "+" + creditsWithCrit;
         }
         else
         {
-            Account.credits += basePoints * multiplicator * multiplicatorOfSkin;
+            int creditsWithoutCrit = basePoints * multiplicator * multiplicatorOfSkin;
+            Account.credits += creditsWithoutCrit;
             VisualizeButtonClick();
+            clicktext.text = "+" + creditsWithoutCrit;
         }
         
     }

--- a/Assets/Scripts/MainGame/DummyButton.cs
+++ b/Assets/Scripts/MainGame/DummyButton.cs
@@ -28,7 +28,9 @@ public class DummyButton : MonoBehaviour
         {
 
             int pointsWithCrit = (int)System.Math.Round(basePoints * multiplicator * multiplicatorOfSkin * criticalMultiplicator);
+            clicktext.color = Color.red;
             clicktext.text = "+" + pointsWithCrit;
+            
         }
         else
         { 
@@ -37,6 +39,8 @@ public class DummyButton : MonoBehaviour
 
         }
     }
+
+
 
     public void MainButtonAction()
     {
@@ -75,13 +79,12 @@ public class DummyButton : MonoBehaviour
     }
 
     public void VisualizeButtonClick() {
-        
         visualClickObject.SetActive(false);
-        visualClickObject.transform.position = new Vector3(Random.Range(800f ,1300f + 1), Random.Range(500f,650f + 1), 0);
+        visualClickObject.transform.position = new Vector3(Random.Range(Screen.width / 2 * 0.9f,Screen.width /2 * 1.4f), Random.Range(Screen.height / 2 * 0.9f,Screen.height / 2 * 1.15f), 0);
         visualClickObject.SetActive(true);
         StopAllCoroutines();
         StartCoroutine(Fly());
-
+        
     }
 
     IEnumerator Fly() {

--- a/Assets/Scripts/MainGame/DummyButton.cs
+++ b/Assets/Scripts/MainGame/DummyButton.cs
@@ -80,7 +80,7 @@ public class DummyButton : MonoBehaviour
 
     public void VisualizeButtonClick() {
         visualClickObject.SetActive(false);
-        visualClickObject.transform.position = new Vector3(Random.Range(Screen.width / 2 * 0.9f,Screen.width /2 * 1.4f), Random.Range(Screen.height / 2 * 0.9f,Screen.height / 2 * 1.15f), 0);
+        visualClickObject.transform.position = new Vector3(Random.Range(Screen.width / 2 * 0.95f,Screen.width /2 * 1.35f), Random.Range(Screen.height / 2 * 0.85f,Screen.height / 2 * 1.18f), 0);
         visualClickObject.SetActive(true);
         StopAllCoroutines();
         StartCoroutine(Fly());


### PR DESCRIPTION
Wenn auf dem Knopf gedrückt wird, erscheint zufällig in einem bestimmten Bereich Zahlen, die den hinzugefügten Credits entsprechen.
Wenn nicht darauf geklickt wird, erscheinen keine Zahlen.
Wenn ein doppelter Ertrag gekauft wird, erhöht sich die Zahl (+1, +2, +3, +8 etc.).
Bei kritischen Treffern sollte die sich die Farbe der Zahl ändern (noch nicht getestet).

AC’s:

    Unsichtbares Feld, in der die Zahl spawnen kann
    Zahl soll den hinzugefügten Credits beim Klicken den MainButton ensprechen
    Es soll keine Zahl erscheinen, wenn der MainButton nicht geklickt wird
    ggf bei Critcal Hits soll Schriftgröße und Farbe anders sein
    ggf random pos der Zahl