### PR TITLE
Labtskinc 256 item critical hit

### DIFF
--- a/Assets/Scripts/Common/ItemNames.cs
+++ b/Assets/Scripts/Common/ItemNames.cs
@@ -8,10 +8,12 @@ using UnityEngine.UI;
 /*
  * This is an alternative to a enum class. C# enums only support integers means no strings.
  * So this workaround is better and simpler than adding methods to a enum class.
+ * The Value of the string is the title of this item.
  */
 public static class ItemNames
 {
     public static readonly string DoubleEffect = "Double Effect";
     public static readonly string Worker = "Worker";
     public static readonly string TestEffect = "Test Effect";
+    public static readonly string CriticalHitEffect = "Critical Hit";
 }

--- a/Assets/Scripts/MainGame/ContentDistributor.cs
+++ b/Assets/Scripts/MainGame/ContentDistributor.cs
@@ -66,20 +66,21 @@ public class ContentDistributor : MonoBehaviour
     {
         var doubleEffect = new DoubleEffect();
         var doubleEffectTemplate = CreateItemTemplate(doubleEffect);
-        itemsDictionary.Add(doubleEffect.id.ToString(), doubleEffect);
 
         var testEffect = new TestEffect();
         var testEffectTemplate = CreateItemTemplate(testEffect);
-        itemsDictionary.Add(testEffect.id.ToString(), testEffect);
 
         var worker = new Worker();
         var workerTemplate = CreateItemTemplate(worker);
-        itemsDictionary.Add(worker.id.ToString(), worker);
 
-        scriptableObjectItems = new ItemTemplate[3];
+        var criticalHit = new CriticalHitEffect();
+        var criticalHitTemplate = CreateItemTemplate(criticalHit);
+
+        scriptableObjectItems = new ItemTemplate[4];
         scriptableObjectItems[0] = doubleEffectTemplate;
         scriptableObjectItems[1] = testEffectTemplate;
         scriptableObjectItems[2] = workerTemplate;
+        scriptableObjectItems[3] = criticalHitTemplate;
 
     }
 
@@ -91,12 +92,9 @@ public class ContentDistributor : MonoBehaviour
     {
         var testSkin = new TestSkin();
         var testSkinTemplate = CreateSkinTemplate(testSkin);
-        skinsDictionary.Add(testSkin.id.ToString(), testSkin);
-
 
         var testSkinTwo = new TestSkinTwo();
         var testSkinTemplate2 = CreateSkinTemplate(testSkinTwo);
-        skinsDictionary.Add(testSkinTwo.id.ToString(), testSkinTwo);
 
         scriptableObjectSkins = new SkinTemplate[2];
         scriptableObjectSkins[0] = testSkinTemplate;
@@ -120,6 +118,8 @@ public class ContentDistributor : MonoBehaviour
         skinTemplate.fullPicture = null;
         skin.skinTemplate = skinTemplate;
 
+        skinsDictionary.Add(skin.id.ToString(), skin);
+
         return skinTemplate;
     }
 
@@ -137,6 +137,8 @@ public class ContentDistributor : MonoBehaviour
         itemTemplate.startPrice = item.price;
         itemTemplate.icon = item.icon;
         item.shopItem = itemTemplate;
+
+        itemsDictionary.Add(item.id.ToString(), item);
 
         return itemTemplate;
     }
@@ -171,7 +173,8 @@ public class ContentDistributor : MonoBehaviour
     {
         foreach (SkinTemplate skin in scriptableObjectSkins)
         {
-            if (Account.IsSkinIdInSkinIdList(skin.id)){
+            if (Account.IsSkinIdInSkinIdList(skin.id))
+            {
                 skinsDictionary[skin.id].PurchaseButtonAction(skin);
                 if (Account.activeSkinId.Equals(skin.id))
                 {

--- a/Assets/Scripts/MainGame/DummyButton.cs
+++ b/Assets/Scripts/MainGame/DummyButton.cs
@@ -40,7 +40,7 @@ public class DummyButton : MonoBehaviour
             clicktext.color = Color.black;
             clicktext.text = "+" + creditsWithoutCrit;
         }
-        
+
     }
 
     public void WorkerAction(int worker)
@@ -49,9 +49,9 @@ public class DummyButton : MonoBehaviour
     }
 
 
-    public void SetMultiplicator(int multi)
+    public void MultiplyMultiplicator(int multi)
     {
-        multiplicator = multi;
+        multiplicator *= multi;
     }
 
     public void SetSkin(Sprite skin)
@@ -63,23 +63,25 @@ public class DummyButton : MonoBehaviour
         this.GetComponent<RectTransform>().localScale = new Vector3(1, 2.4f, 1);
     }
 
-    public void VisualizeButtonClick() {
+    public void VisualizeButtonClick()
+    {
         visualClickObject.SetActive(false);
-        visualClickObject.transform.position = 
-            new Vector3(Random.Range(Screen.width / 2 * 0.95f,Screen.width /2 * 1.3f), Random.Range(Screen.height / 2 * 0.8f,Screen.height / 2 * 1.18f), 0);
+        visualClickObject.transform.position =
+            new Vector3(Random.Range(Screen.width / 2 * 0.95f, Screen.width / 2 * 1.3f), Random.Range(Screen.height / 2 * 0.8f, Screen.height / 2 * 1.18f), 0);
         visualClickObject.SetActive(true);
         StopAllCoroutines();
         StartCoroutine(Fly());
     }
 
     // Numbers are flying for 19 pixels upwards
-    IEnumerator Fly() {
-        for (int i = 0; i <= 19; i++) 
-        { 
-        yield return new WaitForSeconds(0.01f);
-        visualClickObject.transform.position = new Vector3(visualClickObject.transform.position.x, visualClickObject.transform.position.y + 2, 0);
+    IEnumerator Fly()
+    {
+        for (int i = 0; i <= 19; i++)
+        {
+            yield return new WaitForSeconds(0.01f);
+            visualClickObject.transform.position = new Vector3(visualClickObject.transform.position.x, visualClickObject.transform.position.y + 2, 0);
         }
-        visualClickObject.SetActive(false) ;
+        visualClickObject.SetActive(false);
     }
-    
+
 }

--- a/Assets/Scripts/MainGame/DummyButton.cs
+++ b/Assets/Scripts/MainGame/DummyButton.cs
@@ -6,9 +6,9 @@ using UnityEngine.UI;
 
 public class DummyButton : MonoBehaviour
 {
-    public int multiplicator = 1;
+    public int multiplier = 1;
     public int basePoints = 1;
-    public int multiplicatorOfSkin = 1;
+    public int multiplierOfSkin = 1;
     public static float criticalMultiplier = 1.5f;
     public static float criticalChance = 0f;
 
@@ -26,7 +26,7 @@ public class DummyButton : MonoBehaviour
         float randValue = Random.value;
         if (randValue > (1.0f - criticalChance))
         {
-            int creditsWithCrit = (int)System.Math.Round(basePoints * multiplicator * multiplicatorOfSkin * criticalMultiplier);
+            int creditsWithCrit = (int)System.Math.Round(basePoints * multiplier * multiplierOfSkin * criticalMultiplier);
             Account.credits += creditsWithCrit;
             VisualizeButtonClick();
             clicktext.color = Color.red;
@@ -34,7 +34,7 @@ public class DummyButton : MonoBehaviour
         }
         else
         {
-            int creditsWithoutCrit = basePoints * multiplicator * multiplicatorOfSkin;
+            int creditsWithoutCrit = basePoints * multiplier * multiplierOfSkin;
             Account.credits += creditsWithoutCrit;
             VisualizeButtonClick();
             clicktext.color = Color.black;
@@ -45,13 +45,17 @@ public class DummyButton : MonoBehaviour
 
     public void WorkerAction(int worker)
     {
-        Account.credits += basePoints * multiplicatorOfSkin * worker;
+        Account.credits += basePoints * multiplierOfSkin * worker;
     }
 
 
     public void MultiplyMultiplier(int multi)
     {
-        multiplicator *= multi;
+        multiplier *= multi;
+    }
+
+    public void RemoveMultiplier(int multi) {
+        multiplier /= multi;
     }
 
     public void AddCriticalChance(float chance)
@@ -59,9 +63,27 @@ public class DummyButton : MonoBehaviour
         criticalChance += chance;
     }
 
+    public void RemoveCriticalChance(float chance) {
+        criticalChance -= chance;
+    }
+
     public void MultiplyCriticalMultiplier(float critMulti)
     {
         criticalMultiplier *= critMulti;
+    }
+
+    public void RemoveCriticalMultiplier(float critMulti)
+    {
+        criticalMultiplier /= critMulti;
+    }
+
+    public void SetSkinMultiplier(int multi) {
+        multiplierOfSkin = multi;
+    }
+
+    public void RemoveSkinMultiplier()
+    {
+        multiplierOfSkin = 1;
     }
 
     public void SetSkin(Sprite skin)

--- a/Assets/Scripts/MainGame/DummyButton.cs
+++ b/Assets/Scripts/MainGame/DummyButton.cs
@@ -9,7 +9,7 @@ public class DummyButton : MonoBehaviour
     public int multiplicator = 1;
     public int basePoints = 1;
     public int multiplicatorOfSkin = 1;
-    public static float criticalMultiplicator = 1;
+    public static float criticalMultiplier = 1.5f;
     public static float criticalChance = 0f;
 
     public GameObject visualClickObject;
@@ -26,7 +26,7 @@ public class DummyButton : MonoBehaviour
         float randValue = Random.value;
         if (randValue > (1.0f - criticalChance))
         {
-            int creditsWithCrit = (int)System.Math.Round(basePoints * multiplicator * multiplicatorOfSkin * criticalMultiplicator);
+            int creditsWithCrit = (int)System.Math.Round(basePoints * multiplicator * multiplicatorOfSkin * criticalMultiplier);
             Account.credits += creditsWithCrit;
             VisualizeButtonClick();
             clicktext.color = Color.red;
@@ -49,9 +49,19 @@ public class DummyButton : MonoBehaviour
     }
 
 
-    public void MultiplyMultiplicator(int multi)
+    public void MultiplyMultiplier(int multi)
     {
         multiplicator *= multi;
+    }
+
+    public void AddCriticalChance(float chance)
+    {
+        criticalChance += chance;
+    }
+
+    public void MultiplyCriticalMultiplier(float critMulti)
+    {
+        criticalMultiplier *= critMulti;
     }
 
     public void SetSkin(Sprite skin)

--- a/Assets/Scripts/MainGame/InventorySystem/SkinsInventory/SkinInventoryManager.cs
+++ b/Assets/Scripts/MainGame/InventorySystem/SkinsInventory/SkinInventoryManager.cs
@@ -75,7 +75,7 @@ public class SkinInventoryManager : MonoBehaviour
     */
     public void UseButtonAction(int pos)
     {
-        //only woking, if there are no stacks!
+        if (Account.ActiveSkin != null) {Account.ActiveSkin.UnequipSkin();}
         SkinEffect item = (SkinEffect)Account.skinList[pos];
         item.EquipSkin();
         //inventoryPanelsGO[ContentDistributor.contentDistributor.boughtSkinsOfPlayer.Count - 1].   SetFancyEffectToSeeThatSkinIsActive()

--- a/Assets/Scripts/MainGame/Items/ItemEffect/CriticalHitEffect.cs
+++ b/Assets/Scripts/MainGame/Items/ItemEffect/CriticalHitEffect.cs
@@ -7,11 +7,12 @@ public class CriticalHitEffect : ItemEffect
 
     public override string id { get; set; } = ItemNames.CriticalHitEffect;
     public override int price { get; set; } = 2;
-    public override string description { get; set; } = "Increase Critical Hits by 5%.\n" +
+    public override string description { get; set; } = "Increase Critical Hit by " + critChance + "%.\n" +
                                                         "Item is stackable.";
     public override string rarity { get; set; } = Rarities.Common;
     public override Sprite icon { get; set; } = Resources.Load<Sprite>("");
     public override ItemTemplate shopItem { get; set; }
+    private static float critChance = 0.05f;
 
     public override void PurchaseButtonAction(ItemTemplate shopItem)
     {
@@ -29,7 +30,7 @@ public class CriticalHitEffect : ItemEffect
 
     public override void EffectOfItem()
     {
-
+        ContentDistributor.contentDistributor.mainButton.AddCriticalChance(critChance);
     }
 
     public override int CalculateNewAmount()

--- a/Assets/Scripts/MainGame/Items/ItemEffect/CriticalHitEffect.cs
+++ b/Assets/Scripts/MainGame/Items/ItemEffect/CriticalHitEffect.cs
@@ -1,25 +1,17 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.UI;
 
-public class DoubleEffect : ItemEffect
+public class CriticalHitEffect : ItemEffect
 {
-    //Amount of Double/2X Item in player inventory. 
-    public override string id { get; set; } = ItemNames.DoubleEffect;
+
+    public override string id { get; set; } = ItemNames.CriticalHitEffect;
     public override int price { get; set; } = 2;
-    public override string description { get; set; } = "Doubles score and credits.\nItem is stackable.";
+    public override string description { get; set; } = "Increase Critical Hits by 5%.\n" +
+                                                        "Item is stackable.";
     public override string rarity { get; set; } = Rarities.Common;
-    public override Sprite icon { get; set; } = Resources.Load<Sprite>("2X");
+    public override Sprite icon { get; set; } = Resources.Load<Sprite>("");
     public override ItemTemplate shopItem { get; set; }
-    public int multiplicator = 2;
-
-
-
-    public void Start()
-    {
-        shopItem.price = price;
-    }
 
     public override void PurchaseButtonAction(ItemTemplate shopItem)
     {
@@ -32,22 +24,18 @@ public class DoubleEffect : ItemEffect
     //Increasment is hardcoded, if changed, also change tests of TestDoubleEffect.
     public override int CalculateNewPrice()
     {
-        return shopItem.price *= 4;
+        return price * 2;
     }
 
     public override void EffectOfItem()
     {
-        ContentDistributor.contentDistributor.mainButton.MultiplyMultiplicator(multiplicator);
+
     }
 
     public override int CalculateNewAmount()
     {
         shopItem.amount += 1;
         int newAmount = shopItem.amount;
-        GameObject.Find("multipledouble")
-          .GetComponent<VisualFeedbackDouble>()
-          .ChangeCreditLabelAfterBuyingMultipleDoubles(newAmount);
-        Debug.Log(newAmount);
         return newAmount;
     }
 }

--- a/Assets/Scripts/MainGame/Items/ItemEffect/CriticalHitEffect.cs
+++ b/Assets/Scripts/MainGame/Items/ItemEffect/CriticalHitEffect.cs
@@ -25,7 +25,7 @@ public class CriticalHitEffect : ItemEffect
     //Increasment is hardcoded, if changed, also change tests of TestDoubleEffect.
     public override int CalculateNewPrice()
     {
-        return price * 2;
+        return shopItem.price *= 10;
     }
 
     public override void EffectOfItem()

--- a/Assets/Scripts/MainGame/Items/ItemEffect/CriticalHitEffect.cs
+++ b/Assets/Scripts/MainGame/Items/ItemEffect/CriticalHitEffect.cs
@@ -7,7 +7,7 @@ public class CriticalHitEffect : ItemEffect
 
     public override string id { get; set; } = ItemNames.CriticalHitEffect;
     public override int price { get; set; } = 2;
-    public override string description { get; set; } = "Increase Critical Hit by " + critChance + "%.\n" +
+    public override string description { get; set; } = "Increase Critical Hit by " + (int)(critChance * 100) + "%.\n" +
                                                         "Item is stackable.";
     public override string rarity { get; set; } = Rarities.Common;
     public override Sprite icon { get; set; } = Resources.Load<Sprite>("");

--- a/Assets/Scripts/MainGame/Items/ItemEffect/CriticalHitEffect.cs.meta
+++ b/Assets/Scripts/MainGame/Items/ItemEffect/CriticalHitEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 204e40eb04a07044585b96f26a4fb6c3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MainGame/Items/ItemEffect/DoubleEffect.cs
+++ b/Assets/Scripts/MainGame/Items/ItemEffect/DoubleEffect.cs
@@ -12,7 +12,7 @@ public class DoubleEffect : ItemEffect
     public override string rarity { get; set; } = Rarities.Common;
     public override Sprite icon { get; set; } = Resources.Load<Sprite>("2X");
     public override ItemTemplate shopItem { get; set; }
-    public int multiplicator = 2;
+    public int multiplier = 2;
 
 
 
@@ -37,7 +37,7 @@ public class DoubleEffect : ItemEffect
 
     public override void EffectOfItem()
     {
-        ContentDistributor.contentDistributor.mainButton.MultiplyMultiplicator(multiplicator);
+        ContentDistributor.contentDistributor.mainButton.MultiplyMultiplier(multiplier);
     }
 
     public override int CalculateNewAmount()
@@ -47,7 +47,6 @@ public class DoubleEffect : ItemEffect
         GameObject.Find("multipledouble")
           .GetComponent<VisualFeedbackDouble>()
           .ChangeCreditLabelAfterBuyingMultipleDoubles(newAmount);
-        Debug.Log(newAmount);
         return newAmount;
     }
 }

--- a/Assets/Scripts/MainGame/Skins/SkinsEffect/SkinEffect.cs
+++ b/Assets/Scripts/MainGame/Skins/SkinsEffect/SkinEffect.cs
@@ -13,9 +13,9 @@ public abstract class SkinEffect
     public abstract string description { get; set; }
     public abstract bool bought { get; set; }
     public abstract string rarity { get; set; }
-    public abstract int multiplicatorOfSkin { get; set; }
+    public abstract int multiplierOfSkin { get; set; }
     public abstract float criticalChance { get; set; }
-    public abstract float criticalMultiplicator { get; set; }
+    public abstract float criticalMultiplier { get; set; }
     public abstract Sprite icon { get; set; }
     public abstract SkinTemplate skinTemplate { get; set; }
 

--- a/Assets/Scripts/MainGame/Skins/SkinsEffect/SkinEffect.cs
+++ b/Assets/Scripts/MainGame/Skins/SkinsEffect/SkinEffect.cs
@@ -28,4 +28,5 @@ public abstract class SkinEffect
 
     //Uses/Equips skin --> setter for current skin.
     public abstract void EquipSkin();
+    public abstract void UnequipSkin();
 }

--- a/Assets/Scripts/MainGame/Skins/SkinsEffect/TestSkin.cs
+++ b/Assets/Scripts/MainGame/Skins/SkinsEffect/TestSkin.cs
@@ -24,17 +24,26 @@ public class TestSkin : SkinEffect
         Account.skinList.Add(this);
     }
 
-    public override void EffectOfSkin()
-    {
-        ContentDistributor.contentDistributor.mainButton.multiplicatorOfSkin = multiplierOfSkin;
-        ContentDistributor.contentDistributor.mainButton.AddCriticalChance(criticalChance);
-        ContentDistributor.contentDistributor.mainButton.MultiplyCriticalMultiplier(criticalMultiplier);
-    }
-
     public override void EquipSkin()
     {
         Account.ActiveSkin = this;
         EffectOfSkin();
         ContentDistributor.contentDistributor.mainButton.SetSkin(icon);
+    }
+
+    public override void EffectOfSkin()
+    {
+        ContentDistributor.contentDistributor.mainButton.SetSkinMultiplier(skinMulti);
+        ContentDistributor.contentDistributor.mainButton.AddCriticalChance(criticalChance);
+        ContentDistributor.contentDistributor.mainButton.MultiplyCriticalMultiplier(criticalMultiplier);
+    }
+
+
+    public override void UnequipSkin()
+    {
+        Account.ActiveSkin = null;
+        ContentDistributor.contentDistributor.mainButton.RemoveSkinMultiplier();
+        ContentDistributor.contentDistributor.mainButton.RemoveCriticalChance(criticalChance);
+        ContentDistributor.contentDistributor.mainButton.RemoveCriticalMultiplier(criticalMultiplier);
     }
 }

--- a/Assets/Scripts/MainGame/Skins/SkinsEffect/TestSkin.cs
+++ b/Assets/Scripts/MainGame/Skins/SkinsEffect/TestSkin.cs
@@ -9,12 +9,12 @@ public class TestSkin : SkinEffect
     public static int critMulti = 10;
     public override string id { get; set; } = SkinNames.TestEffect;
     public override int price { get; set; } = 10;
-    public override string description { get; set; } = "TestSkin with good buffs!\nSkin Multiplicator: " + skinMulti + "\nCritical Chance: " + critChance + "\nCritical Multiplicator: " + critMulti;
+    public override string description { get; set; } = "TestSkin with good buffs!\nSkin Multiplier: " + skinMulti + "\nCritical Chance: " + critChance + "\nCritical Multiplier: " + critMulti;
     public override bool bought { get; set; } = false;
     public override string rarity { get; set; } = Rarities.Legendary;
-    public override int multiplicatorOfSkin { get; set; } = skinMulti;
+    public override int multiplierOfSkin { get; set; } = skinMulti;
     public override float criticalChance { get; set; } = critChance;
-    public override float criticalMultiplicator { get; set; } = critMulti;
+    public override float criticalMultiplier { get; set; } = critMulti;
     public override Sprite icon { get; set; } = Resources.Load<Sprite>("OurBoiii");
     public override SkinTemplate skinTemplate { get; set; }
 
@@ -26,9 +26,9 @@ public class TestSkin : SkinEffect
 
     public override void EffectOfSkin()
     {
-        ContentDistributor.contentDistributor.mainButton.multiplicatorOfSkin = multiplicatorOfSkin;
-        DummyButton.criticalChance = criticalChance;
-        DummyButton.criticalMultiplicator = criticalMultiplicator;
+        ContentDistributor.contentDistributor.mainButton.multiplicatorOfSkin = multiplierOfSkin;
+        ContentDistributor.contentDistributor.mainButton.AddCriticalChance(criticalChance);
+        ContentDistributor.contentDistributor.mainButton.MultiplyCriticalMultiplier(criticalMultiplier);
     }
 
     public override void EquipSkin()

--- a/Assets/Scripts/MainGame/Skins/SkinsEffect/TestSkin.cs
+++ b/Assets/Scripts/MainGame/Skins/SkinsEffect/TestSkin.cs
@@ -41,7 +41,6 @@ public class TestSkin : SkinEffect
 
     public override void UnequipSkin()
     {
-        Account.ActiveSkin = null;
         ContentDistributor.contentDistributor.mainButton.RemoveSkinMultiplier();
         ContentDistributor.contentDistributor.mainButton.RemoveCriticalChance(criticalChance);
         ContentDistributor.contentDistributor.mainButton.RemoveCriticalMultiplier(criticalMultiplier);

--- a/Assets/Scripts/MainGame/Skins/SkinsEffect/TestSkinTwo.cs
+++ b/Assets/Scripts/MainGame/Skins/SkinsEffect/TestSkinTwo.cs
@@ -31,7 +31,7 @@ public class TestSkinTwo : SkinEffect
 
     public override void EffectOfSkin()
     {
-        ContentDistributor.contentDistributor.mainButton.multiplicatorOfSkin = multiplierOfSkin;
+        ContentDistributor.contentDistributor.mainButton.SetSkinMultiplier(skinMulti);
         ContentDistributor.contentDistributor.mainButton.AddCriticalChance(criticalChance);
         ContentDistributor.contentDistributor.mainButton.MultiplyCriticalMultiplier(criticalMultiplier);
 
@@ -46,6 +46,14 @@ public class TestSkinTwo : SkinEffect
         ContentDistributor.contentDistributor.mainButton.SetSkin(icon);
         Account.ActiveSkin = this;
         EffectOfSkin();
+    }
+
+    public override void UnequipSkin()
+    {
+        Account.ActiveSkin = null;
+        ContentDistributor.contentDistributor.mainButton.RemoveSkinMultiplier();
+        ContentDistributor.contentDistributor.mainButton.RemoveCriticalChance(criticalChance);
+        ContentDistributor.contentDistributor.mainButton.RemoveCriticalMultiplier(criticalMultiplier);
     }
 }
 

--- a/Assets/Scripts/MainGame/Skins/SkinsEffect/TestSkinTwo.cs
+++ b/Assets/Scripts/MainGame/Skins/SkinsEffect/TestSkinTwo.cs
@@ -12,12 +12,12 @@ public class TestSkinTwo : SkinEffect
     public static int critMulti = 90;
     public override string id { get; set; } = SkinNames.TestEffectTwo;
     public override int price { get; set; } = 4;
-    public override string description { get; set; } = "Low Crit-Chance, high reward, random color, much wow\nSkin Multiplicator: " + skinMulti + "\nCritical Chance: " + critChance + "\nCritical Multiplicator: " + critMulti;
+    public override string description { get; set; } = "Low Crit-Chance, high reward, random color, much wow\nSkin Multiplier: " + skinMulti + "\nCritical Chance: " + critChance + "\nCritical Multiplier: " + critMulti;
     public override bool bought { get; set; } = false;
     public override string rarity { get; set; } = Rarities.Rare;
-    public override int multiplicatorOfSkin { get; set; } = skinMulti;
+    public override int multiplierOfSkin { get; set; } = skinMulti;
     public override float criticalChance { get; set; } = critChance;
-    public override float criticalMultiplicator { get; set; } = critMulti;
+    public override float criticalMultiplier { get; set; } = critMulti;
     public override Sprite icon { get; set; } = Resources.Load<Sprite>("BerkanF.Nur");
     public override SkinTemplate skinTemplate { get; set; }
     private GameObject mainButton;
@@ -31,9 +31,9 @@ public class TestSkinTwo : SkinEffect
 
     public override void EffectOfSkin()
     {
-        ContentDistributor.contentDistributor.mainButton.multiplicatorOfSkin = multiplicatorOfSkin;
-        DummyButton.criticalChance = criticalChance;
-        DummyButton.criticalMultiplicator = criticalMultiplicator;
+        ContentDistributor.contentDistributor.mainButton.multiplicatorOfSkin = multiplierOfSkin;
+        ContentDistributor.contentDistributor.mainButton.AddCriticalChance(criticalChance);
+        ContentDistributor.contentDistributor.mainButton.MultiplyCriticalMultiplier(criticalMultiplier);
 
         GameObject canvasGameObject = GameObject.Find("Canvas");
         mainButton = FindObjectHelper.

--- a/Assets/Scripts/MainGame/Skins/SkinsEffect/TestSkinTwo.cs
+++ b/Assets/Scripts/MainGame/Skins/SkinsEffect/TestSkinTwo.cs
@@ -50,7 +50,6 @@ public class TestSkinTwo : SkinEffect
 
     public override void UnequipSkin()
     {
-        Account.ActiveSkin = null;
         ContentDistributor.contentDistributor.mainButton.RemoveSkinMultiplier();
         ContentDistributor.contentDistributor.mainButton.RemoveCriticalChance(criticalChance);
         ContentDistributor.contentDistributor.mainButton.RemoveCriticalMultiplier(criticalMultiplier);

--- a/Assets/Tests/PlayMode/MainGame/Shop/TestCriticalHit.cs
+++ b/Assets/Tests/PlayMode/MainGame/Shop/TestCriticalHit.cs
@@ -1,0 +1,92 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+using UnityEngine.UI;
+
+public class TestCriticalHit : MonoBehaviour
+{
+    private GameObject canvasGameObject;
+    private ContentDistributor distributor;
+    private Button mainButton;
+    public string critId = ItemNames.CriticalHitEffect;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        SceneManager.LoadScene("MainGame");
+    }
+
+
+    [UnitySetUp]
+    public IEnumerator Setup()
+    {
+        yield return null; //Wait till next update
+        canvasGameObject = GameObject.Find("Canvas");
+
+        GameObject contentDistributor = FindObjectHelper.
+            FindObjectInParent(canvasGameObject, "ContentDistributor");
+        distributor = contentDistributor.GetComponentInParent<ContentDistributor>();
+
+        GameObject mainButton = FindObjectHelper.
+            FindObjectInParent(canvasGameObject, "MainButton");
+        this.mainButton = mainButton.GetComponent<Button>();
+    }
+
+    [UnityTest]
+    public IEnumerator TestDoubleEffect()
+    {
+        DummyButton button = mainButton.GetComponent<DummyButton>();
+        DummyButton.criticalChance = 0;
+        yield return null;
+
+        CriticalHitEffect effect = new CriticalHitEffect();
+        effect.EffectOfItem();
+        yield return null;
+
+        Assert.AreEqual(DummyButton.criticalChance, 0.05f);
+        yield return null;
+
+        effect.EffectOfItem();
+        Assert.AreEqual(DummyButton.criticalChance, 0.1f);
+
+    }
+
+    [UnityTest]
+    public IEnumerator TestDoubleEffectPurchaseButtonAction()
+    {
+        CriticalHitEffect effect = new CriticalHitEffect();
+        int startPrice = effect.price;
+        int startAmount = 0;
+        ItemTemplate item = new ItemTemplate();
+        item.amount = startAmount;
+        item.description = "Random Description";
+        item.id = critId;
+        item.icon = null;
+        item.price = startPrice;
+        item.title = critId;
+
+        Assert.AreEqual(startAmount, item.amount);
+        Assert.AreEqual(startPrice, effect.price);
+        yield return null;
+
+        Debug.Log("First");
+        startPrice *= 10;
+        Debug.Log("startPrice = " + startPrice);
+        startAmount += 1;
+        effect.PurchaseButtonAction(item);
+        Debug.Log("startPrice = " + startPrice);
+        Assert.AreEqual(startAmount, item.amount);
+        Assert.AreEqual(startPrice, item.price);
+        yield return null;
+
+        Debug.Log("Sec");
+        startPrice *= 10;
+        startAmount += 1;
+        effect.PurchaseButtonAction(item);
+        Assert.AreEqual(startAmount, item.amount);
+        Assert.AreEqual(startPrice, item.price);
+    }
+}

--- a/Assets/Tests/PlayMode/MainGame/Shop/TestCriticalHit.cs.meta
+++ b/Assets/Tests/PlayMode/MainGame/Shop/TestCriticalHit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f6cb2e246fc04174893187b2402cd842
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/PlayMode/MainGame/Shop/TestDoubleEffect.cs
+++ b/Assets/Tests/PlayMode/MainGame/Shop/TestDoubleEffect.cs
@@ -39,18 +39,18 @@ public class Test : MonoBehaviour
     public IEnumerator TestDoubleEffect()
     {
         DummyButton button = mainButton.GetComponent<DummyButton>();
-        button.multiplicator = 1;
+        button.multiplier = 1;
         yield return null;
 
         DoubleEffect effect = new DoubleEffect();
         effect.EffectOfItem();
         yield return null;
 
-        Assert.AreEqual(button.multiplicator, 2);
+        Assert.AreEqual(button.multiplier, 2);
         yield return null;
 
         effect.EffectOfItem();
-        Assert.AreEqual(button.multiplicator, 4);
+        Assert.AreEqual(button.multiplier, 4);
 
     }
 

--- a/Assets/Tests/PlayMode/MainGame/Shop/TestWorkerEffect.cs
+++ b/Assets/Tests/PlayMode/MainGame/Shop/TestWorkerEffect.cs
@@ -41,7 +41,7 @@ public class TestWorkerEffect : MonoBehaviour
     {
         int demoCredits = 0;
         DummyButton button = mainButton.GetComponent<DummyButton>();
-        button.multiplicator = 1;
+        button.multiplier = 1;
         button.basePoints = 1;
         Account.credits = demoCredits;
         yield return null;
@@ -95,7 +95,7 @@ public class TestWorkerEffect : MonoBehaviour
     public IEnumerator TestEffectOfWorker()
     {
         DummyButton button = mainButton.GetComponent<DummyButton>();
-        button.multiplicator = 1;
+        button.multiplier = 1;
         Account.credits = 0;
         yield return null;
 
@@ -114,7 +114,7 @@ public class TestWorkerEffect : MonoBehaviour
     public IEnumerator TestTwoWorkers()
     {
         DummyButton button = mainButton.GetComponent<DummyButton>();
-        button.multiplicator = 1;
+        button.multiplier = 1;
         Account.credits = 0;
         yield return null;
 


### PR DESCRIPTION
Es soll mit einer 5% Wahrscheinlichkeit einen Critial Hit ausgelöst werden. Sollte das Item öfters gekauft werden, wird die Wahrscheinlichkeit erhöht.


AC’s

Neues EffecItem CriticalHitEffect erstellen

Logik Implementieren

Item in Shop aufnehmen

Test schreiben